### PR TITLE
memory optimization for playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ python fast_td3/train.py --env_name h1hand-hurdle-v0 --exp_name FastTD3 --render
 ### MuJoCo Playground Experiments
 ```bash
 conda activate fasttd3_playground
-python fast_td3/train.py --env_name G1JoystickRoughTerrain --exp_name FastTD3 --render_interval 5000 --seed 1
+python fast_td3/train.py --env_name T1JoystickFlatTerrain --exp_name FastTD3 --render_interval 5000 --seed 1
+python fast_td3/train.py --env_name G1JoystickFlatTerrain --exp_name FastTD3 --render_interval 5000 --seed 1
 ```
 
 ### IsaacLab Experiments

--- a/fast_td3/train.py
+++ b/fast_td3/train.py
@@ -193,6 +193,7 @@ def main():
         n_act=n_act,
         n_critic_obs=n_critic_obs,
         asymmetric_obs=envs.asymmetric_obs,
+        playground_mode=env_type == "mujoco_playground",
         n_steps=args.num_steps,
         gamma=args.gamma,
         device=device,

--- a/fast_td3/training_notebook.ipynb
+++ b/fast_td3/training_notebook.ipynb
@@ -272,6 +272,7 @@
     "    n_act=n_act,\n",
     "    n_critic_obs=n_critic_obs,\n",
     "    asymmetric_obs=envs.asymmetric_obs,\n",
+    "    playground_mode=env_type == \"mujoco_playground\",\n",
     "    n_steps=args.num_steps,\n",
     "    gamma=args.gamma,\n",
     "    device=device,\n",


### PR DESCRIPTION
Using the fact that Playground's `critic_obs` is concatenation of [obs, privileged_obs], this PR does a memory optimization in the replay buffer -- I expect all Playground default hyperparameters should work 24GB GPUs now.

Resolves https://github.com/younggyoseo/FastTD3/issues/1