### PR TITLE
Fix replay buffer issues when n_steps > 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For more information, please see our [project webpage](https://younggyo.me/fast_
 
 
 ## ❗ Updates
-- **[Jun/6/2025]** Thanks to [Antonio Araffin](https://araffin.github.io/) ([@araffin](https://github.com/araffin)), we fixed the issues when using `n_steps` > 1, which stabilizes training with n-step return quite a lot!
+- **[Jun/6/2025]** Thanks to [Antonin Raffin](https://araffin.github.io/) ([@araffin](https://github.com/araffin)), we fixed the issues when using `n_steps` > 1, which stabilizes training with n-step return quite a lot!
 
 - **[Jun/1/2025]** Updated the figures in the technical report to report deterministic evaluation for IsaacLab tasks.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ FastTD3 is a high-performance variant of the Twin Delayed Deep Deterministic Pol
 
 For more information, please see our [project webpage](https://younggyo.me/fast_td3)
 
+
+## ❗ Updates
+- **[Jun/6/2025]** We fixed the issues when using `n_steps` > 3, which stabilizes training with n-step return quite a lot!
+
+- **[Jun/1/2025]** We updated the figures in the technical report to report deterministic evaluation for IsaacLab tasks.
+
+
 ## ✨ Features
 
 FastTD3 offers researchers a significant speedup in training complex humanoid agents.
@@ -150,11 +157,6 @@ We would like to thank people who have helped throughout the project:
 
 - We thank [Kevin Zakka](https://kzakka.com/) for the help in setting up MuJoCo Playground.
 - We thank [Changyeon Kim](https://changyeon.site/) for testing the early version of this codebase
-
-## ❗ Updates
-- **[Jun/6/2025]** We fixed the issues when using `n_steps` > 3, which stabilizes training with n-step return quite a lot!
-
-- **[Jun/1/2025]** We updated the figures in the technical report to report deterministic evaluation for IsaacLab tasks.
 
 ## Citations
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ For more information, please see our [project webpage](https://younggyo.me/fast_
 
 
 ## ❗ Updates
-- **[Jun/6/2025]** We fixed the issues when using `n_steps` > 3, which stabilizes training with n-step return quite a lot!
+- **[Jun/6/2025]** Thanks to [Antonio Araffin](https://araffin.github.io/) ([@araffin](https://github.com/araffin)), we fixed the issues when using `n_steps` > 1, which stabilizes training with n-step return quite a lot!
 
-- **[Jun/1/2025]** We updated the figures in the technical report to report deterministic evaluation for IsaacLab tasks.
+- **[Jun/1/2025]** Updated the figures in the technical report to report deterministic evaluation for IsaacLab tasks.
 
 
 ## ✨ Features

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ We would like to thank people who have helped throughout the project:
 - We thank [Changyeon Kim](https://changyeon.site/) for testing the early version of this codebase
 
 ## ❗ Updates
+- **[Jun/6/2025]** We fixed the issues when using `n_steps` > 3, which stabilizes training with n-step return quite a lot!
+
 - **[Jun/1/2025]** We updated the figures in the technical report to report deterministic evaluation for IsaacLab tasks.
 
 ## Citations

--- a/fast_td3/fast_td3.py
+++ b/fast_td3/fast_td3.py
@@ -124,7 +124,7 @@ class Critic(nn.Module):
         actions: torch.Tensor,
         rewards: torch.Tensor,
         bootstrap: torch.Tensor,
-        gamma: float,
+        discount: float,
     ) -> torch.Tensor:
         """Projection operation that includes q_support directly"""
         q1_proj = self.qnet1.projection(
@@ -132,7 +132,7 @@ class Critic(nn.Module):
             actions,
             rewards,
             bootstrap,
-            gamma,
+            discount,
             self.q_support,
             self.q_support.device,
         )
@@ -141,7 +141,7 @@ class Critic(nn.Module):
             actions,
             rewards,
             bootstrap,
-            gamma,
+            discount,
             self.q_support,
             self.q_support.device,
         )

--- a/fast_td3/fast_td3.py
+++ b/fast_td3/fast_td3.py
@@ -46,7 +46,10 @@ class DistributionalQNetwork(nn.Module):
         delta_z = (self.v_max - self.v_min) / (self.num_atoms - 1)
         batch_size = rewards.shape[0]
 
-        target_z = rewards.unsqueeze(1) + bootstrap.unsqueeze(1) * discount.unsqueeze(1) * q_support
+        target_z = (
+            rewards.unsqueeze(1)
+            + bootstrap.unsqueeze(1) * discount.unsqueeze(1) * q_support
+        )
         target_z = target_z.clamp(self.v_min, self.v_max)
         b = (target_z - self.v_min) / delta_z
         l = torch.floor(b).long()

--- a/fast_td3/fast_td3.py
+++ b/fast_td3/fast_td3.py
@@ -39,14 +39,14 @@ class DistributionalQNetwork(nn.Module):
         actions: torch.Tensor,
         rewards: torch.Tensor,
         bootstrap: torch.Tensor,
-        gamma: float,
+        discount: float,
         q_support: torch.Tensor,
         device: torch.device,
     ) -> torch.Tensor:
         delta_z = (self.v_max - self.v_min) / (self.num_atoms - 1)
         batch_size = rewards.shape[0]
 
-        target_z = rewards.unsqueeze(1) + bootstrap.unsqueeze(1) * gamma * q_support
+        target_z = rewards.unsqueeze(1) + bootstrap.unsqueeze(1) * discount.unsqueeze(1) * q_support
         target_z = target_z.clamp(self.v_min, self.v_max)
         b = (target_z - self.v_min) / delta_z
         l = torch.floor(b).long()

--- a/fast_td3/fast_td3_utils.py
+++ b/fast_td3/fast_td3_utils.py
@@ -193,9 +193,11 @@ class SimpleReplayBuffer(nn.Module):
                 )
                 indices = (current_pos + 1 + rand_offset) % self.buffer_size
             else:
+                # Buffer not full - ensure n-step sequence doesn't exceed valid data
+                max_start_idx = max(1, min(self.buffer_size, self.ptr) - self.n_steps + 1)
                 indices = torch.randint(
                     0,
-                    min(self.buffer_size, self.ptr),
+                    max_start_idx,
                     (self.n_env, batch_size),
                     device=self.device,
                 )

--- a/fast_td3/fast_td3_utils.py
+++ b/fast_td3/fast_td3_utils.py
@@ -153,6 +153,7 @@ class SimpleReplayBuffer(nn.Module):
             truncations = torch.gather(self.truncations, 1, indices).reshape(
                 self.n_env * batch_size
             )
+            effective_n_steps = torch.ones_like(dones)
             if self.asymmetric_obs:
                 if self.playground_mode:
                     # Gather privileged observations
@@ -267,6 +268,7 @@ class SimpleReplayBuffer(nn.Module):
             done_masks = torch.cumprod(
                 1.0 - all_dones_shifted, dim=2
             )  # [n_env, batch_size, n_step]
+            effective_n_steps = done_masks.sum(2)
 
             # Create discount factors
             discounts = torch.pow(
@@ -362,6 +364,7 @@ class SimpleReplayBuffer(nn.Module):
             rewards = n_step_rewards.reshape(self.n_env * batch_size)
             dones = final_dones.reshape(self.n_env * batch_size)
             truncations = final_truncations.reshape(self.n_env * batch_size)
+            effective_n_steps = effective_n_steps.reshape(self.n_env * batch_size)
             next_observations = final_next_observations.reshape(
                 self.n_env * batch_size, self.n_obs
             )
@@ -375,6 +378,7 @@ class SimpleReplayBuffer(nn.Module):
                     "dones": dones,
                     "truncations": truncations,
                     "observations": next_observations,
+                    "effective_n_steps": effective_n_steps,
                 },
             },
             batch_size=self.n_env * batch_size,

--- a/fast_td3/fast_td3_utils.py
+++ b/fast_td3/fast_td3_utils.py
@@ -194,7 +194,9 @@ class SimpleReplayBuffer(nn.Module):
                 indices = (current_pos + 1 + rand_offset) % self.buffer_size
             else:
                 # Buffer not full - ensure n-step sequence doesn't exceed valid data
-                max_start_idx = max(1, min(self.buffer_size, self.ptr) - self.n_steps + 1)
+                max_start_idx = max(
+                    1, min(self.buffer_size, self.ptr) - self.n_steps + 1
+                )
                 indices = torch.randint(
                     0,
                     max_start_idx,

--- a/fast_td3/fast_td3_utils.py
+++ b/fast_td3/fast_td3_utils.py
@@ -185,7 +185,7 @@ class SimpleReplayBuffer(nn.Module):
                 # Buffer is full - avoid dangerous range around current write position
                 current_pos = self.ptr % self.buffer_size
 
-                # Sample from safe region (everything except [avoid_start, avoid_end])
+                # Sample from safe region
                 # This is not fully uniform sampling, but it's good enough with typical buffer sizes
                 safe_size = self.buffer_size - self.n_steps - 1
                 rand_offset = torch.randint(

--- a/fast_td3/fast_td3_utils.py
+++ b/fast_td3/fast_td3_utils.py
@@ -189,7 +189,9 @@ class SimpleReplayBuffer(nn.Module):
                 # TODO (Younggyo): Change the reference when this SB3 branch is merged
                 current_pos = self.ptr % self.buffer_size
                 curr_truncations = self.truncations[:, current_pos - 1].clone()
-                self.truncations[:, current_pos - 1] = torch.logical_not(self.dones[:, current_pos - 1])
+                self.truncations[:, current_pos - 1] = torch.logical_not(
+                    self.dones[:, current_pos - 1]
+                )
                 indices = torch.randint(
                     0,
                     self.buffer_size,
@@ -198,9 +200,7 @@ class SimpleReplayBuffer(nn.Module):
                 )
             else:
                 # Buffer not full - ensure n-step sequence doesn't exceed valid data
-                max_start_idx = max(
-                    1, self.ptr - self.n_steps + 1
-                )
+                max_start_idx = max(1, self.ptr - self.n_steps + 1)
                 indices = torch.randint(
                     0,
                     max_start_idx,
@@ -387,7 +387,7 @@ class SimpleReplayBuffer(nn.Module):
         if self.asymmetric_obs:
             out["critic_observations"] = critic_observations
             out["next"]["critic_observations"] = next_critic_observations
-        
+
         if self.ptr >= self.buffer_size:
             # Roll back the truncation flags introduced for safe sampling
             self.truncations[:, current_pos - 1] = curr_truncations

--- a/fast_td3/fast_td3_utils.py
+++ b/fast_td3/fast_td3_utils.py
@@ -5,13 +5,6 @@ import torch.nn as nn
 
 from tensordict import TensorDict
 
-import os
-
-import torch
-import torch.nn as nn
-
-from tensordict import TensorDict
-
 
 class SimpleReplayBuffer(nn.Module):
     def __init__(

--- a/fast_td3/hyperparams.py
+++ b/fast_td3/hyperparams.py
@@ -418,14 +418,14 @@ class IsaacVelocityFlatH1Args(IsaacLabArgs):
 @dataclass
 class IsaacVelocityFlatG1Args(IsaacLabArgs):
     env_name: str = "Isaac-Velocity-Flat-G1-v0"
-    num_steps: int = 3
+    num_steps: int = 8
     total_timesteps: int = 50000
 
 
 @dataclass
 class IsaacVelocityRoughH1Args(IsaacLabArgs):
     env_name: str = "Isaac-Velocity-Rough-H1-v0"
-    num_steps: int = 3
+    num_steps: int = 8
     buffer_size: int = 1024 * 5  # To reduce memory usage
     total_timesteps: int = 50000
 
@@ -433,7 +433,7 @@ class IsaacVelocityRoughH1Args(IsaacLabArgs):
 @dataclass
 class IsaacVelocityRoughG1Args(IsaacLabArgs):
     env_name: str = "Isaac-Velocity-Rough-G1-v0"
-    num_steps: int = 3
+    num_steps: int = 8
     buffer_size: int = 1024 * 5  # To reduce memory usage
     total_timesteps: int = 50000
 

--- a/fast_td3/hyperparams.py
+++ b/fast_td3/hyperparams.py
@@ -411,7 +411,8 @@ class IsaacOpenDrawerFrankaArgs(IsaacLabArgs):
 @dataclass
 class IsaacVelocityFlatH1Args(IsaacLabArgs):
     env_name: str = "Isaac-Velocity-Flat-H1-v0"
-    num_steps: int = 3
+    num_steps: int = 8
+    num_updates: int = 4
     total_timesteps: int = 75000
 
 
@@ -419,6 +420,7 @@ class IsaacVelocityFlatH1Args(IsaacLabArgs):
 class IsaacVelocityFlatG1Args(IsaacLabArgs):
     env_name: str = "Isaac-Velocity-Flat-G1-v0"
     num_steps: int = 8
+    num_updates: int = 4
     total_timesteps: int = 50000
 
 
@@ -426,6 +428,7 @@ class IsaacVelocityFlatG1Args(IsaacLabArgs):
 class IsaacVelocityRoughH1Args(IsaacLabArgs):
     env_name: str = "Isaac-Velocity-Rough-H1-v0"
     num_steps: int = 8
+    num_updates: int = 4
     buffer_size: int = 1024 * 5  # To reduce memory usage
     total_timesteps: int = 50000
 
@@ -434,6 +437,7 @@ class IsaacVelocityRoughH1Args(IsaacLabArgs):
 class IsaacVelocityRoughG1Args(IsaacLabArgs):
     env_name: str = "Isaac-Velocity-Rough-G1-v0"
     num_steps: int = 8
+    num_updates: int = 4
     buffer_size: int = 1024 * 5  # To reduce memory usage
     total_timesteps: int = 50000
 

--- a/fast_td3/train.py
+++ b/fast_td3/train.py
@@ -305,6 +305,7 @@ def main():
             next_state_actions = (actor(next_observations) + clipped_noise).clamp(
                 action_low, action_high
             )
+            discount = args.gamma ** data["next"]["effective_n_steps"]
 
             with torch.no_grad():
                 qf1_next_target_projected, qf2_next_target_projected = (
@@ -313,7 +314,7 @@ def main():
                         next_state_actions,
                         rewards,
                         bootstrap,
-                        args.gamma,
+                        discount,
                     )
                 )
                 qf1_next_target_value = qnet_target.get_value(qf1_next_target_projected)


### PR DESCRIPTION
This PR should fix issues when `n_steps` is set to >1:
- Issue where the done masking is incorrectly set when computing n_step rewards
- Issue where obs / next_obs are sampled across episodes when the buffer is full
- Issue where discount is incorrectly applied by always using `args.gamma`

Checking the performance before merging this into main branch