### PR TITLE
feat: add Simplicial normalization modules for actor and critic networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For more information, please see our [project webpage](https://younggyo.me/fast_
 
 ## ❗ Updates
 
+- **[May/15/2026]** Added support for FastTD3 + [SEM](https://arxiv.org/abs/2510.13704v1). The codebase now supports Simplicial Embeddings (SimNorm) for FastTD3 actor and critic networks.
+
 - **[Sep/20/2025]** Added `data` directory that contains training logs used for plotting in the report.
 
 - **[Sep/17/2025]** Fixed an issue where `std_min` and `std_max` were not included in Actor config (credit: [@ningyuanz](https://github.com/ningyuanz)).
@@ -236,6 +238,24 @@ python fast_td3/train.py \
     --seed 1
 ```
 
+### FastTD3 + Simplicial Embeddings
+
+FastTD3 supports optional Simplicial Embeddings (SimNorm) for the actor, critic, or both networks. This option is available for `--agent fasttd3` and can be enabled with `--sim_type`.
+
+```bash
+python fast_td3/train.py \
+    --env_name h1hand-hurdle-v0 \
+    --exp_name FastTD3_SimNorm \
+    --render_interval 5000 \
+    --sim_type sim_both \
+    --sim_dimension 64 \
+    --actor_seq_len 8 \
+    --critic_seq_len 8 \
+    --seed 1
+```
+
+Supported `--sim_type` values are `sim_actor`, `sim_critic`, and `sim_both`.
+
 **Quick note:** For boolean-based arguments, you can set them to False by adding `no_` in front each argument, for instance, if you want to disable Clipped Q Learning, you can specify `--no_use_cdq` in your command.
 
 ## 💡 Performance-Related Tips
@@ -299,6 +319,16 @@ We would like to thank people who have helped throughout the project:
   title={FastTD3: Simple, Fast, and Capable Reinforcement Learning for Humanoid Control},
   author={Seo, Younggyo and Sferrazza, Carmelo and Geng, Haoran and Nauman, Michal and Yin, Zhao-Heng and Abbeel, Pieter},
   journal={arXiv preprint arXiv:2505.22642},
+  year={2025}
+}
+```
+
+### Simplicial Embeddings
+```bibtex
+@article{obando2025simplicial,
+  title={Simplicial embeddings improve sample efficiency in actor-critic agents},
+  author={Obando-Ceron, Johan and Mayor, Walter and Lavoie, Samuel and Fujimoto, Scott and Courville, Aaron and Castro, Pablo Samuel},
+  journal={arXiv preprint arXiv:2510.13704},
   year={2025}
 }
 ```

--- a/fast_td3/fast_td3.py
+++ b/fast_td3/fast_td3.py
@@ -2,6 +2,53 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+class SimNorm(nn.Module): 
+    """
+    Simplicial normalization.
+    Adapted from https://arxiv.org/abs/2204.00616.
+    """
+
+    def __init__(self, seq_len=8, simnorm_dim=8):
+        super().__init__()
+        self.L = seq_len
+        self.dim = simnorm_dim
+
+    def forward(self, x):
+        # import pdb
+        # pdb.set_trace()
+        shp = x.shape
+        x = x.view(*shp[:-1], self.L, self.dim)
+        x = F.softmax(x, dim=-1)
+        return x.view(*shp)
+
+    def __repr__(self):
+        return f"Simplicial Embeddings(dim={self.dim})"
+    
+class NormedLinear(nn.Linear):
+    """
+    Linear layer with LayerNorm, activation, and optionally dropout.
+    """
+
+    def __init__(self, *args, dropout=0.0, act=nn.Mish(inplace=True), learnable_ln=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ln = nn.LayerNorm(self.out_features, elementwise_affine=learnable_ln)
+        self.act = act
+        self.dropout = nn.Dropout(dropout, inplace=True) if dropout else None
+
+    def forward(self, x):
+        x = super().forward(x)
+        if self.dropout:
+            x = self.dropout(x)
+        return self.act(self.ln(x))
+
+    def __repr__(self):
+        repr_dropout = f", dropout={self.dropout.p}" if self.dropout else ""
+        return (
+            f"NormedLinear(in_features={self.in_features}, "
+            f"out_features={self.out_features}, "
+            f"bias={self.bias is not None}{repr_dropout}, "
+            f"act={self.act.__class__.__name__})"
+        )
 
 class DistributionalQNetwork(nn.Module):
     def __init__(
@@ -12,18 +59,33 @@ class DistributionalQNetwork(nn.Module):
         v_min: float,
         v_max: float,
         hidden_dim: int,
+        sim_type: str,
+        sim_dimension: int,
+        seq_len: int,
         device: torch.device = None,
     ):
         super().__init__()
         self.net = nn.Sequential(
-            nn.Linear(n_obs + n_act, hidden_dim, device=device),
+            nn.Linear(n_obs + n_act, hidden_dim),
             nn.ReLU(),
-            nn.Linear(hidden_dim, hidden_dim // 2, device=device),
+            nn.Linear(hidden_dim, hidden_dim // 2),
             nn.ReLU(),
-            nn.Linear(hidden_dim // 2, hidden_dim // 4, device=device),
-            nn.ReLU(),
-            nn.Linear(hidden_dim // 4, num_atoms, device=device),
         )
+
+        if  sim_type in ["sim_both", "sim_critic"]:
+            self.act_fn=SimNorm(seq_len, sim_dimension)
+            self.fc_head = nn.Sequential(
+                                NormedLinear(hidden_dim // 2, seq_len*sim_dimension, act=self.act_fn),
+                                nn.Linear(seq_len*sim_dimension, num_atoms),
+                            )
+        else:
+            self.act_fn=None
+            self.fc_head =  nn.Sequential(
+                                nn.Linear(hidden_dim // 2, hidden_dim // 4),
+                                nn.ReLU(),
+                                nn.Linear(hidden_dim // 4, num_atoms),
+                            )
+
         self.v_min = v_min
         self.v_max = v_max
         self.num_atoms = num_atoms
@@ -31,6 +93,7 @@ class DistributionalQNetwork(nn.Module):
     def forward(self, obs: torch.Tensor, actions: torch.Tensor) -> torch.Tensor:
         x = torch.cat([obs, actions], 1)
         x = self.net(x)
+        x = self.fc_head(x)
         return x
 
     def projection(
@@ -55,9 +118,8 @@ class DistributionalQNetwork(nn.Module):
         l = torch.floor(b).long()
         u = torch.ceil(b).long()
 
-        is_int = (l == u)
-        l_mask = is_int & (l > 0)
-        u_mask = is_int & (l == 0)
+        l_mask = torch.logical_and((u > 0), (l == u))
+        u_mask = torch.logical_and((l < (self.num_atoms - 1)), (l == u))
 
         l = torch.where(l_mask, l - 1, l)
         u = torch.where(u_mask, u + 1, u)
@@ -90,6 +152,9 @@ class Critic(nn.Module):
         v_min: float,
         v_max: float,
         hidden_dim: int,
+        sim_type: str,
+        sim_dimension: int,
+        seq_len: int,
         device: torch.device = None,
     ):
         super().__init__()
@@ -100,6 +165,9 @@ class Critic(nn.Module):
             v_min=v_min,
             v_max=v_max,
             hidden_dim=hidden_dim,
+            sim_type=sim_type,
+            sim_dimension=sim_dimension,
+            seq_len=seq_len,
             device=device,
         )
         self.qnet2 = DistributionalQNetwork(
@@ -109,6 +177,9 @@ class Critic(nn.Module):
             v_min=v_min,
             v_max=v_max,
             hidden_dim=hidden_dim,
+            sim_type=sim_type,
+            sim_dimension=sim_dimension,
+            seq_len=seq_len,
             device=device,
         )
 
@@ -164,39 +235,54 @@ class Actor(nn.Module):
         hidden_dim: int,
         std_min: float = 0.05,
         std_max: float = 0.8,
+        sim_type: str = "",
+        sim_dimension: int = 64,
+        seq_len: int=8,
         device: torch.device = None,
     ):
         super().__init__()
         self.n_act = n_act
         self.net = nn.Sequential(
-            nn.Linear(n_obs, hidden_dim, device=device),
+            nn.Linear(n_obs, hidden_dim),
             nn.ReLU(),
-            nn.Linear(hidden_dim, hidden_dim // 2, device=device),
-            nn.ReLU(),
-            nn.Linear(hidden_dim // 2, hidden_dim // 4, device=device),
+            nn.Linear(hidden_dim, hidden_dim // 2),
             nn.ReLU(),
         )
-        self.fc_mu = nn.Sequential(
-            nn.Linear(hidden_dim // 4, n_act, device=device),
-            nn.Tanh(),
-        )
+
+        if sim_type in ["sim_both", "sim_actor"]:
+            self.act_fn = SimNorm(seq_len, sim_dimension)
+            self.fc_head = NormedLinear(hidden_dim // 2, seq_len*sim_dimension, act=self.act_fn)
+            self.fc_mu = nn.Sequential(
+                nn.Linear(seq_len*sim_dimension, n_act),
+                nn.Tanh(),
+            )
+        else:
+            self.fc_head =  nn.Sequential(
+                                nn.Linear(hidden_dim // 2, hidden_dim // 4),
+                                nn.ReLU(),
+                            )
+            self.fc_mu = nn.Sequential(
+                nn.Linear(hidden_dim // 4, n_act),
+                nn.Tanh(),
+            )
         nn.init.normal_(self.fc_mu[0].weight, 0.0, init_scale)
         nn.init.constant_(self.fc_mu[0].bias, 0.0)
 
         noise_scales = (
-            torch.rand(num_envs, 1, device=device) * (std_max - std_min) + std_min
+            torch.rand(num_envs, 1) * (std_max - std_min) + std_min
         )
         self.register_buffer("noise_scales", noise_scales)
 
-        self.register_buffer("std_min", torch.as_tensor(std_min, device=device))
-        self.register_buffer("std_max", torch.as_tensor(std_max, device=device))
+        self.register_buffer("std_min", torch.as_tensor(std_min))
+        self.register_buffer("std_max", torch.as_tensor(std_max))
         self.n_envs = num_envs
         self.device = device
 
     def forward(self, obs: torch.Tensor) -> torch.Tensor:
         x = obs
-        x = self.net(x)
-        action = self.fc_mu(x)
+        x_net = self.net(x)
+        x_head = self.fc_head(x_net)
+        action = self.fc_mu(x_head)
         return action
 
     def explore(

--- a/fast_td3/fast_td3.py
+++ b/fast_td3/fast_td3.py
@@ -2,7 +2,22 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-class SimNorm(nn.Module): 
+
+VALID_SIM_TYPES = {"", "sim_actor", "sim_critic", "sim_both"}
+
+
+def _validate_sim_config(sim_type: str, sim_dimension: int, seq_len: int) -> None:
+    if sim_type not in VALID_SIM_TYPES:
+        raise ValueError(
+            f"Unsupported sim_type '{sim_type}'. Expected one of {sorted(VALID_SIM_TYPES)}"
+        )
+    if sim_dimension <= 0:
+        raise ValueError("sim_dimension must be positive")
+    if seq_len <= 0:
+        raise ValueError("seq_len must be positive")
+
+
+class SimNorm(nn.Module):
     """
     Simplicial normalization.
     Adapted from https://arxiv.org/abs/2204.00616.
@@ -14,41 +29,31 @@ class SimNorm(nn.Module):
         self.dim = simnorm_dim
 
     def forward(self, x):
-        # import pdb
-        # pdb.set_trace()
         shp = x.shape
         x = x.view(*shp[:-1], self.L, self.dim)
         x = F.softmax(x, dim=-1)
         return x.view(*shp)
 
     def __repr__(self):
-        return f"Simplicial Embeddings(dim={self.dim})"
-    
-class NormedLinear(nn.Linear):
-    """
-    Linear layer with LayerNorm, activation, and optionally dropout.
-    """
+        return f"SimNorm(seq_len={self.L}, simnorm_dim={self.dim})"
 
-    def __init__(self, *args, dropout=0.0, act=nn.Mish(inplace=True), learnable_ln=True, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ln = nn.LayerNorm(self.out_features, elementwise_affine=learnable_ln)
-        self.act = act
-        self.dropout = nn.Dropout(dropout, inplace=True) if dropout else None
 
-    def forward(self, x):
-        x = super().forward(x)
-        if self.dropout:
-            x = self.dropout(x)
-        return self.act(self.ln(x))
+class SimNormLinear(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        seq_len: int,
+        simnorm_dim: int,
+        device: torch.device = None,
+    ):
+        super().__init__()
+        out_features = seq_len * simnorm_dim
+        self.linear = nn.Linear(in_features, out_features, device=device)
+        self.norm = nn.LayerNorm(out_features, device=device)
+        self.simnorm = SimNorm(seq_len, simnorm_dim)
 
-    def __repr__(self):
-        repr_dropout = f", dropout={self.dropout.p}" if self.dropout else ""
-        return (
-            f"NormedLinear(in_features={self.in_features}, "
-            f"out_features={self.out_features}, "
-            f"bias={self.bias is not None}{repr_dropout}, "
-            f"act={self.act.__class__.__name__})"
-        )
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.simnorm(self.norm(self.linear(x)))
 
 class DistributionalQNetwork(nn.Module):
     def __init__(
@@ -65,26 +70,31 @@ class DistributionalQNetwork(nn.Module):
         device: torch.device = None,
     ):
         super().__init__()
+        _validate_sim_config(sim_type, sim_dimension, seq_len)
+
         self.net = nn.Sequential(
-            nn.Linear(n_obs + n_act, hidden_dim),
+            nn.Linear(n_obs + n_act, hidden_dim, device=device),
             nn.ReLU(),
-            nn.Linear(hidden_dim, hidden_dim // 2),
+            nn.Linear(hidden_dim, hidden_dim // 2, device=device),
             nn.ReLU(),
         )
 
-        if  sim_type in ["sim_both", "sim_critic"]:
-            self.act_fn=SimNorm(seq_len, sim_dimension)
+        if sim_type in ["sim_both", "sim_critic"]:
             self.fc_head = nn.Sequential(
-                                NormedLinear(hidden_dim // 2, seq_len*sim_dimension, act=self.act_fn),
-                                nn.Linear(seq_len*sim_dimension, num_atoms),
-                            )
+                SimNormLinear(
+                    hidden_dim // 2,
+                    seq_len=seq_len,
+                    simnorm_dim=sim_dimension,
+                    device=device,
+                ),
+                nn.Linear(seq_len * sim_dimension, num_atoms, device=device),
+            )
         else:
-            self.act_fn=None
-            self.fc_head =  nn.Sequential(
-                                nn.Linear(hidden_dim // 2, hidden_dim // 4),
-                                nn.ReLU(),
-                                nn.Linear(hidden_dim // 4, num_atoms),
-                            )
+            self.fc_head = nn.Sequential(
+                nn.Linear(hidden_dim // 2, hidden_dim // 4, device=device),
+                nn.ReLU(),
+                nn.Linear(hidden_dim // 4, num_atoms, device=device),
+            )
 
         self.v_min = v_min
         self.v_max = v_max
@@ -118,8 +128,9 @@ class DistributionalQNetwork(nn.Module):
         l = torch.floor(b).long()
         u = torch.ceil(b).long()
 
-        l_mask = torch.logical_and((u > 0), (l == u))
-        u_mask = torch.logical_and((l < (self.num_atoms - 1)), (l == u))
+        is_int = l == u
+        l_mask = is_int & (l > 0)
+        u_mask = is_int & (l == 0)
 
         l = torch.where(l_mask, l - 1, l)
         u = torch.where(u_mask, u + 1, u)
@@ -241,40 +252,46 @@ class Actor(nn.Module):
         device: torch.device = None,
     ):
         super().__init__()
+        _validate_sim_config(sim_type, sim_dimension, seq_len)
+
         self.n_act = n_act
         self.net = nn.Sequential(
-            nn.Linear(n_obs, hidden_dim),
+            nn.Linear(n_obs, hidden_dim, device=device),
             nn.ReLU(),
-            nn.Linear(hidden_dim, hidden_dim // 2),
+            nn.Linear(hidden_dim, hidden_dim // 2, device=device),
             nn.ReLU(),
         )
 
         if sim_type in ["sim_both", "sim_actor"]:
-            self.act_fn = SimNorm(seq_len, sim_dimension)
-            self.fc_head = NormedLinear(hidden_dim // 2, seq_len*sim_dimension, act=self.act_fn)
+            self.fc_head = SimNormLinear(
+                hidden_dim // 2,
+                seq_len=seq_len,
+                simnorm_dim=sim_dimension,
+                device=device,
+            )
             self.fc_mu = nn.Sequential(
-                nn.Linear(seq_len*sim_dimension, n_act),
+                nn.Linear(seq_len * sim_dimension, n_act, device=device),
                 nn.Tanh(),
             )
         else:
-            self.fc_head =  nn.Sequential(
-                                nn.Linear(hidden_dim // 2, hidden_dim // 4),
-                                nn.ReLU(),
-                            )
+            self.fc_head = nn.Sequential(
+                nn.Linear(hidden_dim // 2, hidden_dim // 4, device=device),
+                nn.ReLU(),
+            )
             self.fc_mu = nn.Sequential(
-                nn.Linear(hidden_dim // 4, n_act),
+                nn.Linear(hidden_dim // 4, n_act, device=device),
                 nn.Tanh(),
             )
         nn.init.normal_(self.fc_mu[0].weight, 0.0, init_scale)
         nn.init.constant_(self.fc_mu[0].bias, 0.0)
 
         noise_scales = (
-            torch.rand(num_envs, 1) * (std_max - std_min) + std_min
+            torch.rand(num_envs, 1, device=device) * (std_max - std_min) + std_min
         )
         self.register_buffer("noise_scales", noise_scales)
 
-        self.register_buffer("std_min", torch.as_tensor(std_min))
-        self.register_buffer("std_max", torch.as_tensor(std_max))
+        self.register_buffer("std_min", torch.as_tensor(std_min, device=device))
+        self.register_buffer("std_max", torch.as_tensor(std_max, device=device))
         self.n_envs = num_envs
         self.device = device
 

--- a/fast_td3/hyperparams.py
+++ b/fast_td3/hyperparams.py
@@ -126,12 +126,13 @@ class BaseArgs:
     """the interval to save the model"""
 
     sim_type: str = ""
-    "where to use the sim activation in the actor, critic or both networks"
+    """SimNorm mode: '', sim_actor, sim_critic, or sim_both"""
     sim_dimension: int = 64
     """the dimension of the sim module"""
     critic_seq_len: int = 8
+    """the number of simplices used in the critic head"""
     actor_seq_len: int = 8
-    """the number of SEMs."""
+    """the number of simplices used in the actor head"""
 
 def get_args():
     """

--- a/fast_td3/hyperparams.py
+++ b/fast_td3/hyperparams.py
@@ -125,6 +125,13 @@ class BaseArgs:
     save_interval: int = 5000
     """the interval to save the model"""
 
+    sim_type: str = ""
+    "where to use the sim activation in the actor, critic or both networks"
+    sim_dimension: int = 64
+    """the dimension of the sim module"""
+    critic_seq_len: int = 8
+    actor_seq_len: int = 8
+    """the number of SEMs."""
 
 def get_args():
     """

--- a/fast_td3/train.py
+++ b/fast_td3/train.py
@@ -182,6 +182,9 @@ def main():
         "hidden_dim": args.actor_hidden_dim,
         "std_min": args.std_min,
         "std_max": args.std_max,
+        "sim_type": args.sim_type,
+        "sim_dimension": args.sim_dimension,
+        "seq_len": args.actor_seq_len,
     }
     critic_kwargs = {
         "n_obs": n_critic_obs,
@@ -190,6 +193,9 @@ def main():
         "v_min": args.v_min,
         "v_max": args.v_max,
         "hidden_dim": args.critic_hidden_dim,
+        "sim_type": args.sim_type,
+        "sim_dimension": args.sim_dimension,
+        "seq_len": args.critic_seq_len,
         "device": device,
     }
 
@@ -253,7 +259,7 @@ def main():
     else:
         raise ValueError(f"Agent {args.agent} not supported")
 
-    actor = actor_cls(**actor_kwargs)
+    actor = actor_cls(**actor_kwargs).to(device)
 
     if env_type in ["mtbench"]:
         # Python 3.8 doesn't support 'from_module' in tensordict
@@ -261,13 +267,13 @@ def main():
     else:
         from tensordict import from_module
 
-        actor_detach = actor_cls(**actor_kwargs)
+        actor_detach = actor_cls(**actor_kwargs).to(device)
         # Copy params to actor_detach without grad
         from_module(actor).data.to_module(actor_detach)
         policy = actor_detach.explore
 
-    qnet = critic_cls(**critic_kwargs)
-    qnet_target = critic_cls(**critic_kwargs)
+    qnet = critic_cls(**critic_kwargs).to(device)
+    qnet_target = critic_cls(**critic_kwargs).to(device)
     qnet_target.load_state_dict(qnet.state_dict())
 
     q_optimizer = optim.AdamW(

--- a/fast_td3/train.py
+++ b/fast_td3/train.py
@@ -182,9 +182,6 @@ def main():
         "hidden_dim": args.actor_hidden_dim,
         "std_min": args.std_min,
         "std_max": args.std_max,
-        "sim_type": args.sim_type,
-        "sim_dimension": args.sim_dimension,
-        "seq_len": args.actor_seq_len,
     }
     critic_kwargs = {
         "n_obs": n_critic_obs,
@@ -193,9 +190,6 @@ def main():
         "v_min": args.v_min,
         "v_max": args.v_max,
         "hidden_dim": args.critic_hidden_dim,
-        "sim_type": args.sim_type,
-        "sim_dimension": args.sim_dimension,
-        "seq_len": args.critic_seq_len,
         "device": device,
     }
 
@@ -219,8 +213,26 @@ def main():
             actor_cls = Actor
             critic_cls = Critic
 
+        actor_kwargs.update(
+            {
+                "sim_type": args.sim_type,
+                "sim_dimension": args.sim_dimension,
+                "seq_len": args.actor_seq_len,
+            }
+        )
+        critic_kwargs.update(
+            {
+                "sim_type": args.sim_type,
+                "sim_dimension": args.sim_dimension,
+                "seq_len": args.critic_seq_len,
+            }
+        )
+
         print("Using FastTD3")
     elif args.agent == "fasttd3_simbav2":
+        if args.sim_type:
+            raise ValueError("SimNorm options are only supported with agent='fasttd3'")
+
         if env_type in ["mtbench"]:
             from fast_td3_simbav2 import MultiTaskActor, MultiTaskCritic
 
@@ -259,7 +271,7 @@ def main():
     else:
         raise ValueError(f"Agent {args.agent} not supported")
 
-    actor = actor_cls(**actor_kwargs).to(device)
+    actor = actor_cls(**actor_kwargs)
 
     if env_type in ["mtbench"]:
         # Python 3.8 doesn't support 'from_module' in tensordict
@@ -267,13 +279,13 @@ def main():
     else:
         from tensordict import from_module
 
-        actor_detach = actor_cls(**actor_kwargs).to(device)
+        actor_detach = actor_cls(**actor_kwargs)
         # Copy params to actor_detach without grad
         from_module(actor).data.to_module(actor_detach)
         policy = actor_detach.explore
 
-    qnet = critic_cls(**critic_kwargs).to(device)
-    qnet_target = critic_cls(**critic_kwargs).to(device)
+    qnet = critic_cls(**critic_kwargs)
+    qnet_target = critic_cls(**critic_kwargs)
     qnet_target.load_state_dict(qnet.state_dict())
 
     q_optimizer = optim.AdamW(

--- a/fast_td3/train_multigpu.py
+++ b/fast_td3/train_multigpu.py
@@ -236,9 +236,27 @@ def main(rank: int, world_size: int):
             actor_cls = Actor
             critic_cls = Critic
 
+        actor_kwargs.update(
+            {
+                "sim_type": args.sim_type,
+                "sim_dimension": args.sim_dimension,
+                "seq_len": args.actor_seq_len,
+            }
+        )
+        critic_kwargs.update(
+            {
+                "sim_type": args.sim_type,
+                "sim_dimension": args.sim_dimension,
+                "seq_len": args.critic_seq_len,
+            }
+        )
+
         if rank == 0:
             print("Using FastTD3")
     elif args.agent == "fasttd3_simbav2":
+        if args.sim_type:
+            raise ValueError("SimNorm options are only supported with agent='fasttd3'")
+
         if env_type in ["mtbench"]:
             from fast_td3_simbav2 import MultiTaskActor, MultiTaskCritic
 


### PR DESCRIPTION
Description

This PR introduces Simplicial Embeddings (SimNorm) as an optional normalization mechanism for both the actor and critic networks.

The goal is to enable experimentation with simplicial representations in fastTD3-style architectures while keeping the existing models fully backward compatible.

SimNorm follows the formulation proposed in
https://arxiv.org/abs/2204.00616

1. Key Changes

New Modules

- SimNorm
   - Implements simplicial normalization.
   - Projects features into a (seq_len × sim_dimension) representation followed by a softmax over the simplicial dimension.

- NormedLinear
  - Wrapper around nn.Linear including:
  - LayerNorm
  - activation
  - optional dropout

2. Architecture Updates

Critic (DistributionalQNetwork)
- Added support for a SimNorm-based head when sim_type is enabled.

Actor
- Actor can optionally apply SimNorm embeddings before the action head.

3. Configuration Changes

New hyperparameters added in hyperparams.py:
- sim_type
     - controls where SimNorm is applied
     - options:
          - sim_actor
          - sim_critic
          - sim_both
- sim_dimension
     - embedding dimension of the simplicial module
- actor_seq_len
- critic_seq_len
     -number of simplicial modules used in each network

4. Training Pipeline

train.py was updated to propagate the new parameters through:
    - actor_kwargs
    - critic_kwargs